### PR TITLE
Use in-tree python package requirements if available

### DIFF
--- a/resources/docker_files/ubuntu-16.04/Dockerfile
+++ b/resources/docker_files/ubuntu-16.04/Dockerfile
@@ -260,10 +260,6 @@ RUN python3 -m pip install 'pip<21' --upgrade | cat && \
     # For mypy, use the earliest version that works with our code base.
     # See https://github.com/ARMmbed/mbedtls/pull/3953 .
     python3 -m pip install mypy==0.780 && \
-    # For jinja2, use the version that's in Ubuntu 20.04.
-    # See https://github.com/ARMmbed/mbedtls/pull/5067#discussion_r738794607 .
-    # Note that Jinja2 3.0 drops support for Python 3.5, so we need 2.x.
-    python3 -m pip install Jinja2==2.10.1 types-Jinja2 && \
     true
 
 # Set locale for ARMCC to work

--- a/resources/docker_files/ubuntu-18.04/Dockerfile
+++ b/resources/docker_files/ubuntu-18.04/Dockerfile
@@ -256,10 +256,6 @@ RUN python3 -m pip install 'pip<21' --upgrade | cat && \
     # For mypy, use the earliest version that works with our code base.
     # See https://github.com/ARMmbed/mbedtls/pull/3953 .
     python3 -m pip install mypy==0.780 && \
-    # For jinja2, use the version that's in Ubuntu 20.04.
-    # See https://github.com/ARMmbed/mbedtls/pull/5067#discussion_r738794607 .
-    # Note that Jinja2 3.0 drops support for Python 3.5, so we need 2.x.
-    python3 -m pip install Jinja2==2.10.1 types-Jinja2 && \
     true
 
 # Set the locale

--- a/vars/common.groovy
+++ b/vars/common.groovy
@@ -121,7 +121,7 @@ docker run -u \$(id -u):\$(id -g) --rm --entrypoint $entrypoint \
 }
 
 /* Get components of all.sh for a list of platforms*/
-def get_all_sh_components(platform_list) {
+def get_branch_information() {
     node('container-host') {
         dir('src') {
             deleteDir()
@@ -129,7 +129,7 @@ def get_all_sh_components(platform_list) {
         }
         // Log the environment for debugging purposes
         sh script: 'export'
-        for (platform in platform_list) {
+        for (platform in linux_platforms) {
             get_docker_image(platform)
             def all_sh_help = sh(
                 script: docker_script(

--- a/vars/common.groovy
+++ b/vars/common.groovy
@@ -51,6 +51,10 @@ import groovy.transform.Field
 @Field available_all_sh_components = [:]
 @Field all_all_sh_components = []
 
+/* We need to know whether the code is C99 in order to decide which versions
+ * of Visual Studio to test with: older versions lack C99 support. */
+@Field code_is_c99 = null
+
 @Field freebsd_all_sh_components = [
     /* Do not include any components that do TLS system testing, because
      * we don't maintain suitable versions of OpenSSL and GnuTLS on
@@ -126,9 +130,17 @@ def get_branch_information() {
         dir('src') {
             deleteDir()
             checkout_repo.checkout_repo()
+
+            // Branches written in C89 (plus very minor extensions) have
+            // "-Wdeclaration-after-statement" in CMakeLists.txt, so look
+            // for that to determine whether the code is supposed to be C89.
+            String cmakelists_contents = readFile('CMakeLists.txt')
+            code_is_c89 = cmakelists_contents.contains('-Wdeclaration-after-statement')
         }
+
         // Log the environment for debugging purposes
         sh script: 'export'
+
         for (platform in linux_platforms) {
             get_docker_image(platform)
             def all_sh_help = sh(
@@ -174,25 +186,13 @@ def check_every_all_sh_component_will_be_run() {
 }
 
 def get_supported_windows_builds() {
-    def is_c89 = null
     def vs_builds = []
-    node('container-host') {
-        dir('src') {
-            deleteDir()
-            checkout_repo.checkout_repo()
-            // Branches written in C89 (plus very minor extensions) have
-            // "-Wdeclaration-after-statement" in CMakeLists.txt, so look
-            // for that to determine whether the code is supposed to be C89.
-            String cmakelists_contents = readFile('CMakeLists.txt')
-            is_c89 = cmakelists_contents.contains('-Wdeclaration-after-statement')
-        }
-    }
     if (env.JOB_TYPE == 'PR') {
         vs_builds = ['2013']
     } else {
         vs_builds = ['2013', '2015', '2017']
     }
-    if (is_c89) {
+    if (code_is_c89) {
         vs_builds = ['2010'] + vs_builds
     }
     echo "vs_builds = ${vs_builds}"

--- a/vars/common.groovy
+++ b/vars/common.groovy
@@ -51,6 +51,11 @@ import groovy.transform.Field
 @Field available_all_sh_components = [:]
 @Field all_all_sh_components = []
 
+/* Whether scripts/min_requirements.py is available. Older branches don't
+ * have it, so they only get what's hard-coded in the docker files on Linux,
+ * and bare python on other platforms. */
+@Field has_min_requirements = null
+
 /* We need to know whether the code is C99 in order to decide which versions
  * of Visual Studio to test with: older versions lack C99 support. */
 @Field code_is_c99 = null
@@ -130,6 +135,8 @@ def get_branch_information() {
         dir('src') {
             deleteDir()
             checkout_repo.checkout_repo()
+
+            has_min_requirements = fileExists('scripts/min_requirements.py')
 
             // Branches written in C89 (plus very minor extensions) have
             // "-Wdeclaration-after-statement" in CMakeLists.txt, so look

--- a/vars/gen_jobs.groovy
+++ b/vars/gen_jobs.groovy
@@ -207,7 +207,7 @@ echo >&2 'Note: "clang" will run /usr/bin/clang -Wno-error=c11-extensions'
 
     if (common.has_min_requirements) {
         extra_setup_code += '''
-scripts/min_requirements.py
+scripts/min_requirements.py --user
 '''
     }
 

--- a/vars/gen_jobs.groovy
+++ b/vars/gen_jobs.groovy
@@ -292,9 +292,11 @@ def gen_windows_testing_job(build, label_prefix='') {
                 }
 
                 if (common.has_min_requirements) {
-                    timeout(time: common.perJobTimeout.time,
-                            unit: common.perJobTimeout.unit) {
-                        bat "python scripts\\min_requirements.py"
+                    dir("src") {
+                        timeout(time: common.perJobTimeout.time,
+                                unit: common.perJobTimeout.unit) {
+                            bat "python scripts\\min_requirements.py"
+                        }
                     }
                 }
 

--- a/vars/gen_jobs.groovy
+++ b/vars/gen_jobs.groovy
@@ -551,12 +551,13 @@ mbedhtrun -m ${platform} ${tag_filter} \
 def gen_release_jobs(label_prefix='', run_examples=true) {
     def jobs = [:]
 
+    common.get_branch_information()
+
     if (env.RUN_BASIC_BUILD_TEST == "true") {
         jobs = jobs + gen_code_coverage_job('ubuntu-16.04');
     }
 
     if (env.RUN_ALL_SH == "true") {
-        common.get_all_sh_components(['ubuntu-16.04', 'ubuntu-18.04'])
         for (component in common.available_all_sh_components['ubuntu-16.04']) {
             jobs = jobs + gen_all_sh_jobs('ubuntu-16.04', component, label_prefix)
         }

--- a/vars/gen_jobs.groovy
+++ b/vars/gen_jobs.groovy
@@ -173,6 +173,7 @@ def gen_all_sh_jobs(platform, component, label_prefix='') {
 export OPENSSL=false GNUTLS_CLI=false GNUTLS_SERV=false
 '''
     }
+
     if (platform.contains('bsd')) {
         /* At the time of writing, all.sh assumes that make is GNU make.
          * But on FreeBSD, make is BSD make and gmake is GNU make.
@@ -201,6 +202,12 @@ exec /usr/bin/clang -Wno-error=c11-extensions "$@"
 EOF
 chmod +x bin/clang
 echo >&2 'Note: "clang" will run /usr/bin/clang -Wno-error=c11-extensions'
+'''
+    }
+
+    if (common.has_min_requirements) {
+        extra_setup_code += '''
+scripts/min_requirements.py
 '''
     }
 
@@ -283,6 +290,14 @@ def gen_windows_testing_job(build, label_prefix='') {
                     deleteDir()
                     writeFile file:'_do_not_delete_this_directory.txt', text:''
                 }
+
+                if (common.has_min_requirements) {
+                    timeout(time: common.perJobTimeout.time,
+                            unit: common.perJobTimeout.unit) {
+                        bat "python scripts\\min_requirements.py"
+                    }
+                }
+
                 /* libraryResource loads the file as a string. This is then
                  * written to a file so that it can be run on a node. */
                 def windows_testing = libraryResource 'windows/windows_testing.py'

--- a/vars/gen_jobs.groovy
+++ b/vars/gen_jobs.groovy
@@ -392,6 +392,11 @@ def gen_code_coverage_job(platform) {
                     writeFile file: 'steps.sh', text: '''#!/bin/sh
 set -eux
 ulimit -f 20971520
+
+if [ -e scripts/min_requirements.py ]; then
+    scripts/min_requirements.py --user
+fi
+
 if grep -q -F coverage-summary.txt tests/scripts/basic-build-test.sh; then
     # New basic-build-test, generates coverage-summary.txt
     ./tests/scripts/basic-build-test.sh

--- a/vars/mbedtls.groovy
+++ b/vars/mbedtls.groovy
@@ -102,7 +102,7 @@ def run_pr_job(is_production=true) {
         stage('pre-test-checks') {
             try {
                 environ.set_tls_pr_environment(is_production)
-                common.get_all_sh_components(['ubuntu-16.04', 'ubuntu-18.04'])
+                common.get_branch_information()
                 common.check_every_all_sh_component_will_be_run()
                 common.maybe_notify_github "Pre Test Checks", 'SUCCESS', 'OK'
             } catch (err) {

--- a/vars/scripts.groovy
+++ b/vars/scripts.groovy
@@ -21,6 +21,7 @@ import groovy.transform.Field
 
 @Field win32_mingw_test_bat = """\
 set CC=gcc
+if exist scripts\\min_requirements.py python scripts\\min_requirements.py || exit
 if exist scripts\\make_generated_files.bat call scripts\\make_generated_files.bat || exit
 cmake . -G "MinGW Makefiles" || exit
 mingw32-make || exit
@@ -31,6 +32,7 @@ programs\\test\\selftest.exe || exit
 
 @Field iar8_mingw_test_bat = """\
 set CC=iccarm
+if exist scripts\\min_requirements.py python scripts\\min_requirements.py || exit
 if exist scripts\\make_generated_files.bat call scripts\\make_generated_files.bat || exit
 perl scripts/config.pl baremetal || exit
 cmake -D CMAKE_BUILD_TYPE:String=Check -G "MinGW Makefiles" . || exit
@@ -40,6 +42,7 @@ mingw32-make lib || exit
 @Field win32_msvc12_32_test_bat = """\
 call "C:\\Program Files (x86)\\Microsoft Visual Studio 12.0\\VC\\vcvarsall.bat" || exit
 set CC=cl
+if exist scripts\\min_requirements.py python scripts\\min_requirements.py || exit
 if exist scripts\\make_generated_files.bat call scripts\\make_generated_files.bat || exit
 cmake . -G "Visual Studio 12" || exit
 MSBuild ALL_BUILD.vcxproj || exit
@@ -49,6 +52,7 @@ programs\\test\\Debug\\selftest.exe || exit
 @Field win32_msvc12_64_test_bat = """\
 call "C:\\Program Files (x86)\\Microsoft Visual Studio 12.0\\VC\\vcvarsall.bat" || exit
 set CC=cl
+if exist scripts\\min_requirements.py python scripts\\min_requirements.py || exit
 if exist scripts\\make_generated_files.bat call scripts\\make_generated_files.bat || exit
 cmake . -G "Visual Studio 12 Win64" || exit
 MSBuild ALL_BUILD.vcxproj || exit


### PR DESCRIPTION
If `scripts/min_requirements.py` exists (added by https://github.com/ARMmbed/mbedtls/pull/5197), run it.

Keep the CI working as before for branches that don't have it. Branches that need jinja2 will need to have `scripts/min_requirements.py` and thus to be based on https://github.com/ARMmbed/mbedtls/pull/5197.

Prerequisites:

* [x] On FreeBSD, pip needs to be installed on the CI. https://jira.arm.com/browse/OSSDEVOPS-3166

### Validation

[see issue history for validation on older commits]

On 775873dd7a0d7198b26f70e35c0b6700418059f5:
* `development` complete — https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/340/ → PASS
* `development_2.x` complete — https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/339/ → PASS
* `mbedtls-2.16` complete — https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/333/ → PASS
* `dev/gilles-peskine-arm/pip-requirements` at 7f29ea6d3966512e33d95700e5c050b3fa6453f2 complete — https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/341/ → PASS
* `dev/gilles-peskine-arm/codegen_1.0-pip` at f0628bdb539634d978a3b38f9044686b3cd61c3d complete — https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/342/ → Fail only (?) in the `code_coverage` job, which is to be retested

On 3c752168287fcd439046d34cb787a2dc8e7c16c0, which differs from 775873dd7a0d7198b26f70e35c0b6700418059f5 only in the code_coverage job:

* `development` code_coverage — https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/344/ → PASS
* `dev/gilles-peskine-arm/codegen_1.0-pip` at f0628bdb539634d978a3b38f9044686b3cd61c3d code_coverage — https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/343/ → PASS

### Status

Ready
