### PR TITLE
Adding coverity push to nightly job

### DIFF
--- a/vars/gen_jobs.groovy
+++ b/vars/gen_jobs.groovy
@@ -587,7 +587,7 @@ def gen_coverity_push_jobs() {
                         deleteDir()
                         checkout_repo.checkout_repo()
                         sshagent([env.GIT_CREDENTIALS_ID]) {
-                            sh 'git push -u origin HEAD:coverity_scan'
+                            sh 'git push origin HEAD:coverity_scan'
                         }
                     }
                 } catch (err) {


### PR DESCRIPTION
## Description

Add a job to push to the coverity scan branch to the nightly tests.

Coverity push is conditional on new environment variable PUSH_COVERITY, so future nightly jobs will have to have that variable turned on in order to enable.

Coverity push will only happen if the nightly is running on development branch.

This closes https://github.com/ARMmbed/mbedtls-test/issues/14

## Testing.

This has been tested via the TEST_BRANCH variable, and found to be working : https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/361/
