### PR TITLE
Add branch name to nightly email notifications

### DIFF
--- a/vars/common.groovy
+++ b/vars/common.groovy
@@ -270,7 +270,6 @@ Logs: ${env.BUILD_URL}
 
 Failures: ${failures}
 """
-        subject = is_open_ci_env ? "TF Open CI ${name} failed!" : "Internal CI ${name} failed! (branch: ${branch})"
         recipients = env.TEST_FAIL_EMAIL_ADDRESS
     } else {
         emailbody = """
@@ -278,9 +277,10 @@ ${coverage_details['coverage']}
 
 Logs: ${env.BUILD_URL}
 """
-        subject = is_open_ci_env ? "TF Open CI ${name} passed!" : "Internal CI ${name} passed! (branch: ${branch})"
         recipients = env.TEST_PASS_EMAIL_ADDRESS
     }
+    subject = ((is_open_ci_env ? "TF Open CI" : "Internal CI") + " ${name} " + \
+           (failed_builds ? "failed" : "passed") + "! (branch: ${branch})")
     echo subject
     echo emailbody
     emailext body: emailbody,

--- a/vars/common.groovy
+++ b/vars/common.groovy
@@ -259,7 +259,7 @@ done
     )
 }
 
-def send_email(name, failed_builds, coverage_details) {
+def send_email(name, branch, failed_builds, coverage_details) {
     if (failed_builds) {
         keys = failed_builds.keySet()
         failures = keys.join(", ")
@@ -270,7 +270,7 @@ Logs: ${env.BUILD_URL}
 
 Failures: ${failures}
 """
-        subject = is_open_ci_env ? "TF Open CI ${name} failed!" : "Internal CI ${name} failed!"
+        subject = is_open_ci_env ? "TF Open CI ${name} failed!" : "Internal CI ${name} failed! (branch: ${branch})"
         recipients = env.TEST_FAIL_EMAIL_ADDRESS
     } else {
         emailbody = """
@@ -278,7 +278,7 @@ ${coverage_details['coverage']}
 
 Logs: ${env.BUILD_URL}
 """
-        subject = is_open_ci_env ? "TF Open CI ${name} passed!" : "Internal CI ${name} passed!"
+        subject = is_open_ci_env ? "TF Open CI ${name} passed!" : "Internal CI ${name} passed! (branch: ${branch})"
         recipients = env.TEST_PASS_EMAIL_ADDRESS
     }
     echo subject
@@ -295,7 +295,7 @@ def run_release_jobs(name, jobs, failed_builds, coverage_details) {
         parallel jobs
     } finally {
         if (currentBuild.rawBuild.getCauses()[0].toString().contains('TimerTriggerCause')) {
-            send_email(name, failed_builds, coverage_details)
+            send_email(name, env.MBED_TLS_BRANCH, failed_builds, coverage_details)
         }
     }
 }


### PR DESCRIPTION
Make nightly results easier to see at a glance (and filter) by adding the branch name to the email subject.

Successful test run here: https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/366/